### PR TITLE
snap: added native build support for armhf and use dynamic arch triplet

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: oval-core-tools
 base: core22
-version: '0.9'
+version: '0.10'
 summary: This snap provides basic tools for CVE Reporting on Ubuntu Core.
 description: |
   This snap provides basic tools for OVAL-based CVE Reporting on Ubuntu Core.
@@ -13,14 +13,14 @@ architectures:
     build-for: [ 'amd64' ]
   - build-on: [ 'arm64' ]
     build-for: [ 'arm64' ]
-  - build-on: [ 'arm64' ]
+  - build-on: [ 'armhf' ]
     build-for: [ 'armhf' ]
 
 apps:
   cvereport:
     command: cvereport.sh
     environment:
-        LD_LIBRARY_PATH: $SNAP/usr/lib/x86_64-linux-gnu/android:$LD_LIBRARY_PATH
+        LD_LIBRARY_PATH: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/android:$LD_LIBRARY_PATH
 
 parts:
   oval-tools:


### PR DESCRIPTION
- Added native build support for armhf
- Use dynamic arch triplet
- Update snap version to 0.10
